### PR TITLE
Fix NullPointerException when trying to read nonexistent ETag field i…

### DIFF
--- a/src/main/java/org/swisspush/reststorage/RedisStorage.java
+++ b/src/main/java/org/swisspush/reststorage/RedisStorage.java
@@ -662,7 +662,8 @@ public class RedisStorage implements Storage {
             } else {
                 r.readStream = new ByteArrayReadStream(content);
                 r.length = content.length;
-                r.etag = values.get(2).toString();
+                Response etagRsp = values.get(2);
+                r.etag = etagRsp == null ? null : etagRsp.toString();
                 r.closeHandler = event -> {
                     // nothing to close
                 };


### PR DESCRIPTION
Fix NullPointerException when trying to read nonexistent ETag field in resource.

Prior to the vertx upgrade the ETag was optional in a resource. This was changed to unintentionally throw a NullPointerException when it was not available. This change restores this behaviour.