### PR TITLE
[SDCISA-13110] Support Redis 6.x authentication method

### DIFF
--- a/src/main/java/org/swisspush/reststorage/DefaultRedisProvider.java
+++ b/src/main/java/org/swisspush/reststorage/DefaultRedisProvider.java
@@ -84,8 +84,9 @@ public class DefaultRedisProvider implements RedisProvider {
         StringBuilder connectionStringBuilder = new StringBuilder();
         connectionStringBuilder.append(configuration.isRedisEnableTls() ? "rediss://" : "redis://");
         String redisUser = configuration.getRedisUser();
-        if (StringUtils.isNotEmpty(redisUser)) {
-            connectionStringBuilder.append(configuration.getRedisUser()).append(":").append(configuration.getRedisAuth()).append("@");
+        String redisPassword = configuration.getRedisPassword();
+        if (StringUtils.isNotEmpty(redisUser) && StringUtils.isNotEmpty(redisPassword)) {
+            connectionStringBuilder.append(configuration.getRedisUser()).append(":").append(redisPassword).append("@");
         }
         connectionStringBuilder.append(configuration.getRedisHost()).append(":").append(configuration.getRedisPort());
         return connectionStringBuilder.toString();

--- a/src/main/java/org/swisspush/reststorage/DefaultRedisProvider.java
+++ b/src/main/java/org/swisspush/reststorage/DefaultRedisProvider.java
@@ -6,6 +6,7 @@ import io.vertx.core.Vertx;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.RedisOptions;
+import org.apache.commons.lang.StringUtils;
 import org.swisspush.reststorage.util.ModuleConfiguration;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -62,9 +63,8 @@ public class DefaultRedisProvider implements RedisProvider {
 
     private Future<RedisAPI> connectToRedis() {
         Promise<RedisAPI> promise = Promise.promise();
-        String protocol =  configuration.isRedisEnableTls() ? "rediss://" : "redis://";
         Redis.createClient(vertx, new RedisOptions()
-                .setConnectionString(protocol + configuration.getRedisHost() + ":" + configuration.getRedisPort())
+                .setConnectionString(createConnectString())
                 .setPassword((configuration.getRedisAuth() == null ? "" : configuration.getRedisAuth()))
                 .setMaxPoolSize(configuration.getMaxRedisConnectionPoolSize())
                 .setMaxPoolWaiting(configuration.getMaxQueueWaiting())
@@ -78,5 +78,16 @@ public class DefaultRedisProvider implements RedisProvider {
         });
 
         return promise.future();
+    }
+
+    private String createConnectString() {
+        StringBuilder connectionStringBuilder = new StringBuilder();
+        connectionStringBuilder.append(configuration.isRedisEnableTls() ? "rediss://" : "redis://");
+        String redisUser = configuration.getRedisUser();
+        if (StringUtils.isNotEmpty(redisUser)) {
+            connectionStringBuilder.append(configuration.getRedisUser()).append(":").append(configuration.getRedisAuth()).append("@");
+        }
+        connectionStringBuilder.append(configuration.getRedisHost()).append(":").append(configuration.getRedisPort());
+        return connectionStringBuilder.toString();
     }
 }

--- a/src/main/java/org/swisspush/reststorage/util/ModuleConfiguration.java
+++ b/src/main/java/org/swisspush/reststorage/util/ModuleConfiguration.java
@@ -1,7 +1,6 @@
 package org.swisspush.reststorage.util;
 
 import io.vertx.core.json.JsonObject;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +32,12 @@ public class ModuleConfiguration {
     private String redisHost = "localhost";
     private int redisPort = 6379;
     private boolean redisEnableTls;
+    /**
+     * @deprecated Instance authentication is considered as legacy. With Redis from 6.x on the ACL authentication method should be used.
+     */
+    @Deprecated(since = "3.0.17")
     private String redisAuth = null;
+    private String redisPassword = null;
     private String redisUser = null;
     private String expirablePrefix = "rest-storage:expirable";
     private String resourcesPrefix = "rest-storage:resources";
@@ -121,8 +125,14 @@ public class ModuleConfiguration {
         return this;
     }
 
+    @Deprecated(since = "3.0.17")
     public ModuleConfiguration redisAuth(String redisAuth) {
         this.redisAuth = redisAuth;
+        return this;
+    }
+
+    public ModuleConfiguration redisPassword(String redisPassword) {
+        this.redisPassword = redisPassword;
         return this;
     }
 
@@ -255,6 +265,10 @@ public class ModuleConfiguration {
 
     public String getRedisAuth() {
         return redisAuth;
+    }
+
+    public String getRedisPassword() {
+        return redisPassword;
     }
 
     public String getRedisUser() {

--- a/src/main/java/org/swisspush/reststorage/util/ModuleConfiguration.java
+++ b/src/main/java/org/swisspush/reststorage/util/ModuleConfiguration.java
@@ -1,6 +1,7 @@
 package org.swisspush.reststorage.util;
 
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ public class ModuleConfiguration {
     private int redisPort = 6379;
     private boolean redisEnableTls;
     private String redisAuth = null;
+    private String redisUser = null;
     private String expirablePrefix = "rest-storage:expirable";
     private String resourcesPrefix = "rest-storage:resources";
     private String collectionsPrefix = "rest-storage:collections";
@@ -121,6 +123,11 @@ public class ModuleConfiguration {
 
     public ModuleConfiguration redisAuth(String redisAuth) {
         this.redisAuth = redisAuth;
+        return this;
+    }
+
+    public ModuleConfiguration redisUser(String redisUser) {
+        this.redisUser = redisUser;
         return this;
     }
 
@@ -248,6 +255,10 @@ public class ModuleConfiguration {
 
     public String getRedisAuth() {
         return redisAuth;
+    }
+
+    public String getRedisUser() {
+        return redisUser;
     }
 
     public String getExpirablePrefix() {

--- a/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
+++ b/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
@@ -40,6 +40,9 @@ public class ModuleConfigurationTest {
         testContext.assertEquals(config.getRedisHost(), "localhost");
         testContext.assertEquals(config.getRedisPort(), 6379);
         testContext.assertFalse(config.isRedisEnableTls());
+        testContext.assertNull(config.getRedisAuth());
+        testContext.assertNull(config.getRedisUser());
+        testContext.assertNull(config.getRedisPassword());
         testContext.assertEquals(config.getExpirablePrefix(), "rest-storage:expirable");
         testContext.assertEquals(config.getResourcesPrefix(), "rest-storage:resources");
         testContext.assertEquals(config.getCollectionsPrefix(), "rest-storage:collections");

--- a/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
+++ b/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
@@ -129,6 +129,8 @@ public class ModuleConfigurationTest {
         testContext.assertEquals(json.getInteger("redisPort"), 6379);
         testContext.assertEquals(json.getInteger("maxRedisWaitingHandlers"), 2048);
         testContext.assertNull(json.getString("redisAuth"));
+        testContext.assertNull(json.getString("redisPassword"));
+        testContext.assertNull(json.getString("redisUser"));
         testContext.assertEquals(json.getString("expirablePrefix"), "rest-storage:expirable");
         testContext.assertEquals(json.getString("resourcesPrefix"), "rest-storage:resources");
         testContext.assertEquals(json.getString("collectionsPrefix"), "rest-storage:collections");

--- a/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
+++ b/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
@@ -63,6 +63,8 @@ public class ModuleConfigurationTest {
                 .redisHost("anotherhost")
                 .redisPort(1234)
                 .redisEnableTls(true)
+                .redisUser("myUser")
+                .redisPassword("secretPassword")
                 .editorConfig(new HashMap<>() {{
                     put("myKey", "myValue");
                 }})
@@ -98,6 +100,8 @@ public class ModuleConfigurationTest {
         testContext.assertEquals(config.getRedisHost(), "anotherhost");
         testContext.assertEquals(config.getRedisPort(), 1234);
         testContext.assertTrue(config.isRedisEnableTls());
+        testContext.assertEquals(config.getRedisUser(), "myUser");
+        testContext.assertEquals(config.getRedisPassword(), "secretPassword");
         testContext.assertFalse(config.isHttpRequestHandlerEnabled());
         testContext.assertNotNull(config.getEditorConfig());
         testContext.assertTrue(config.getEditorConfig().containsKey("myKey"));


### PR DESCRIPTION
- added username and password authentication

Made redisques aware of new ACL authentication method introduced with Redis 6.