### PR TITLE
#124 Added reconnect to DefaultRedisProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,31 +188,34 @@ The data compression feature is not compatible with all vertx-rest-storage featu
 
 The following configuration values are available:
 
-| Property                                | Type   | Default value            | Description                                                                                                                   | 
-|:----------------------------------------|:-------|:-------------------------|:------------------------------------------------------------------------------------------------------------------------------|
-| root                                    | common | .                        | The prefix for the directory or redis key                                                                                     |
-| storageType                             | common | filesystem               | The storage implementation to use. Choose between filesystem or redis                                                         |
-| port                                    | common | 8989                     | The port the mod listens to when HTTP API is enabled.                                                                         |
-| httpRequestHandlerEnabled               | common | true                     | When set to _false_, the storage is accessible throught the event bus only.                                                   |
-| httpRequestHandlerAuthenticationEnabled | common | false                    | Enable / disable authentication for the HTTP API                                                                              |
-| httpRequestHandlerUsername              | common |                          | The username for the HTTP API authentication                                                                                  |
-| httpRequestHandlerPassword              | common |                          | The password for the HTTP API authentication                                                                                  |
-| prefix                                  | common | /                        | The part of the URL path before this handler (aka "context path" in JEE terminology)                                          |
-| storageAddress                          | common | resource-storage         | The eventbus address the mod listens to.                                                                                      |
-| editorConfig                            | common |                          | Additional configuration values for the editor                                                                                |
-| confirmCollectionDelete                 | common | false                    | When set to _true_, an additional _recursive=true_ url parameter has to be set to delete collections                          |
-| redisHost                               | redis  | localhost                | The host where redis is running on                                                                                            |
-| redisPort                               | redis  | 6379                     | The port where redis is running on                                                                                            |
-| expirablePrefix                         | redis  | rest-storage:expirable   | The prefix for expirable data redis keys                                                                                      |
-| resourcesPrefix                         | redis  | rest-storage:resources   | The prefix for resources redis keys                                                                                           |
-| collectionsPrefix                       | redis  | rest-storage:collections | The prefix for collections redis keys                                                                                         |
-| deltaResourcesPrefix                    | redis  | delta:resources          | The prefix for delta resources redis keys                                                                                     |
-| deltaEtagsPrefix                        | redis  | delta:etags              | The prefix for delta etags redis keys                                                                                         |
-| lockPrefix                              | redis  | rest-storage:locks       | The prefix for lock redis keys                                                                                                |
-| resourceCleanupAmount                   | redis  | 100000                   | The maximum amount of resources to clean in a single cleanup run                                                              |
-| resourceCleanupIntervalSec              | redis  |                          | The interval (in seconds) how often to peform the storage cleanup. When set to _null_ no periodic storage cleanup is peformed |
-| rejectStorageWriteOnLowMemory           | redis  | false                    | When set to _true_, PUT requests with the x-importance-level header can be rejected when memory gets low                      |
-| freeMemoryCheckIntervalMs               | redis  | 60000                    | The interval in milliseconds to calculate the actual memory usage                                                             |
+| Property                                | Type   | Default value            | Description                                                                                                                           | 
+|:----------------------------------------|:-------|:-------------------------|:--------------------------------------------------------------------------------------------------------------------------------------|
+| root                                    | common | .                        | The prefix for the directory or redis key                                                                                             |
+| storageType                             | common | filesystem               | The storage implementation to use. Choose between filesystem or redis                                                                 |
+| port                                    | common | 8989                     | The port the mod listens to when HTTP API is enabled.                                                                                 |
+| httpRequestHandlerEnabled               | common | true                     | When set to _false_, the storage is accessible throught the event bus only.                                                           |
+| httpRequestHandlerAuthenticationEnabled | common | false                    | Enable / disable authentication for the HTTP API                                                                                      |
+| httpRequestHandlerUsername              | common |                          | The username for the HTTP API authentication                                                                                          |
+| httpRequestHandlerPassword              | common |                          | The password for the HTTP API authentication                                                                                          |
+| prefix                                  | common | /                        | The part of the URL path before this handler (aka "context path" in JEE terminology)                                                  |
+| storageAddress                          | common | resource-storage         | The eventbus address the mod listens to.                                                                                              |
+| editorConfig                            | common |                          | Additional configuration values for the editor                                                                                        |
+| confirmCollectionDelete                 | common | false                    | When set to _true_, an additional _recursive=true_ url parameter has to be set to delete collections                                  |
+| redisHost                               | redis  | localhost                | The host where redis is running on                                                                                                    |
+| redisPort                               | redis  | 6379                     | The port where redis is running on                                                                                                    |
+| redisReconnectAttempts                  | redis  | 0                        | The amount of reconnect attempts when connection to redis is lost. Use _-1_ for continuous reconnects or _0_ for no reconnects at all |
+| redisReconnectDelaySec                  | redis  | 30                       | The delay (in seconds) between each reconnect attempt                                                                                 |
+| redisPoolRecycleTimeoutMs               | redis  | 180000                   | The timeout [ms] when the connection pool is recycled. Use **-1** when having reconnect feature enabled.                              |
+| expirablePrefix                         | redis  | rest-storage:expirable   | The prefix for expirable data redis keys                                                                                              |
+| resourcesPrefix                         | redis  | rest-storage:resources   | The prefix for resources redis keys                                                                                                   |
+| collectionsPrefix                       | redis  | rest-storage:collections | The prefix for collections redis keys                                                                                                 |
+| deltaResourcesPrefix                    | redis  | delta:resources          | The prefix for delta resources redis keys                                                                                             |
+| deltaEtagsPrefix                        | redis  | delta:etags              | The prefix for delta etags redis keys                                                                                                 |
+| lockPrefix                              | redis  | rest-storage:locks       | The prefix for lock redis keys                                                                                                        |
+| resourceCleanupAmount                   | redis  | 100000                   | The maximum amount of resources to clean in a single cleanup run                                                                      |
+| resourceCleanupIntervalSec              | redis  |                          | The interval (in seconds) how often to peform the storage cleanup. When set to _null_ no periodic storage cleanup is peformed         |
+| rejectStorageWriteOnLowMemory           | redis  | false                    | When set to _true_, PUT requests with the x-importance-level header can be rejected when memory gets low                              |
+| freeMemoryCheckIntervalMs               | redis  | 60000                    | The interval in milliseconds to calculate the actual memory usage                                                                     |
 
 ### Configuration util
 

--- a/src/main/java/org/swisspush/reststorage/RedisRestStorageRunner.java
+++ b/src/main/java/org/swisspush/reststorage/RedisRestStorageRunner.java
@@ -15,6 +15,8 @@ public class RedisRestStorageRunner {
     public static void main(String[] args) {
         ModuleConfiguration modConfig = new ModuleConfiguration()
                 .storageType(ModuleConfiguration.StorageType.redis)
+                .redisReconnectAttempts(-1)
+                .redisPoolRecycleTimeoutMs(-1)
                 .resourceCleanupIntervalSec(10);
 
         Vertx.vertx().deployVerticle(new RestStorageMod(), new DeploymentOptions().setConfig(modConfig.asJsonObject()), event ->

--- a/src/main/java/org/swisspush/reststorage/util/ModuleConfiguration.java
+++ b/src/main/java/org/swisspush/reststorage/util/ModuleConfiguration.java
@@ -37,6 +37,9 @@ public class ModuleConfiguration {
      */
     @Deprecated(since = "3.0.17")
     private String redisAuth = null;
+    private int redisReconnectAttempts = 0;
+    private int redisReconnectDelaySec = 30;
+    private int redisPoolRecycleTimeoutMs = 180_000;
     private String redisPassword = null;
     private String redisUser = null;
     private String expirablePrefix = "rest-storage:expirable";
@@ -123,6 +126,21 @@ public class ModuleConfiguration {
 
     public ModuleConfiguration redisEnableTls(boolean redisEnableTls) {
         this.redisEnableTls = redisEnableTls;
+        return this;
+    }
+
+    public ModuleConfiguration redisReconnectAttempts(int redisReconnectAttempts) {
+        this.redisReconnectAttempts = redisReconnectAttempts;
+        return this;
+    }
+
+    public ModuleConfiguration redisReconnectDelaySec(int redisReconnectDelaySec) {
+        this.redisReconnectDelaySec = redisReconnectDelaySec;
+        return this;
+    }
+
+    public ModuleConfiguration redisPoolRecycleTimeoutMs(int redisPoolRecycleTimeoutMs) {
+        this.redisPoolRecycleTimeoutMs = redisPoolRecycleTimeoutMs;
         return this;
     }
 
@@ -268,6 +286,22 @@ public class ModuleConfiguration {
 
     public int getRedisPort() {
         return redisPort;
+    }
+
+    public int getRedisReconnectAttempts() {
+        return redisReconnectAttempts;
+    }
+
+    public int getRedisReconnectDelaySec() {
+        if (redisReconnectDelaySec < 1) {
+            log.debug("Ignoring value {}s for redisReconnectDelay (too small) and use 1 instead", redisReconnectDelaySec);
+            return 1;
+        }
+        return redisReconnectDelaySec;
+    }
+
+    public int getRedisPoolRecycleTimeoutMs() {
+        return redisPoolRecycleTimeoutMs;
     }
 
     public boolean isRedisEnableTls() {

--- a/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
+++ b/src/test/java/org/swisspush/reststorage/util/ModuleConfigurationTest.java
@@ -137,6 +137,9 @@ public class ModuleConfigurationTest {
         testContext.assertNull(json.getJsonObject("editorConfig"));
         testContext.assertEquals(json.getString("redisHost"), "localhost");
         testContext.assertEquals(json.getInteger("redisPort"), 6379);
+        testContext.assertEquals(json.getInteger("redisReconnectAttempts"), 0);
+        testContext.assertEquals(json.getInteger("redisReconnectDelaySec"), 30);
+        testContext.assertEquals(json.getInteger("redisPoolRecycleTimeoutMs"), 180000);
         testContext.assertEquals(json.getInteger("maxRedisWaitingHandlers"), 2048);
         testContext.assertNull(json.getString("redisAuth"));
         testContext.assertNull(json.getString("redisPassword"));
@@ -159,6 +162,9 @@ public class ModuleConfigurationTest {
         ModuleConfiguration config = new ModuleConfiguration()
                 .redisHost("anotherhost")
                 .redisPort(1234)
+                .redisReconnectAttempts(-1)
+                .redisReconnectDelaySec(0)
+                .redisPoolRecycleTimeoutMs(-1)
                 .redisEnableTls(true)
                 .editorConfig(new HashMap<>() {{
                     put("myKey", "myValue");
@@ -194,6 +200,9 @@ public class ModuleConfigurationTest {
         // overridden values
         testContext.assertEquals(json.getString("redisHost"), "anotherhost");
         testContext.assertEquals(json.getInteger("redisPort"), 1234);
+        testContext.assertEquals(json.getInteger("redisReconnectAttempts"), -1);
+        testContext.assertEquals(json.getInteger("redisReconnectDelaySec"), 1);
+        testContext.assertEquals(json.getInteger("redisPoolRecycleTimeoutMs"), -1);
         testContext.assertTrue(json.getBoolean("redisEnableTls"));
         testContext.assertTrue(json.getBoolean("confirmCollectionDelete"));
         testContext.assertTrue(json.getBoolean("rejectStorageWriteOnLowMemory"));
@@ -218,6 +227,9 @@ public class ModuleConfigurationTest {
         testContext.assertEquals(config.getRoot(), ".");
         testContext.assertEquals(config.getStorageType(), StorageType.filesystem);
         testContext.assertEquals(config.getPort(), 8989);
+        testContext.assertEquals(config.getRedisReconnectAttempts(), 0);
+        testContext.assertEquals(config.getRedisReconnectDelaySec(), 30);
+        testContext.assertEquals(config.getRedisPoolRecycleTimeoutMs(), 180000);
         testContext.assertEquals(config.getPrefix(), "");
         testContext.assertEquals(config.getStorageAddress(), "resource-storage");
         testContext.assertNull(config.getEditorConfig());
@@ -249,6 +261,9 @@ public class ModuleConfigurationTest {
         json.put("root", "newroot");
         json.put("storageType", "redis");
         json.put("port", 1234);
+        json.put("redisReconnectAttempts", 15);
+        json.put("redisReconnectDelaySec", -5);
+        json.put("redisPoolRecycleTimeoutMs", -5);
         json.put("redisEnableTls", true);
         json.put("httpRequestHandlerEnabled", false);
         json.put("httpRequestHandlerAuthenticationEnabled", true);
@@ -276,6 +291,9 @@ public class ModuleConfigurationTest {
         testContext.assertEquals(config.getRoot(), "newroot");
         testContext.assertEquals(config.getStorageType(), StorageType.redis);
         testContext.assertEquals(config.getPort(), 1234);
+        testContext.assertEquals(config.getRedisReconnectAttempts(), 15);
+        testContext.assertEquals(config.getRedisReconnectDelaySec(), 1);
+        testContext.assertEquals(config.getRedisPoolRecycleTimeoutMs(), -5);
         testContext.assertTrue(config.isRedisEnableTls());
         testContext.assertFalse(config.isHttpRequestHandlerEnabled());
         testContext.assertTrue(config.isHttpRequestHandlerAuthenticationEnabled());


### PR DESCRIPTION
These changes have already been implemented in [PR 125](https://github.com/swisspost/vertx-rest-storage/pull/125) and [PR 127](https://github.com/swisspost/vertx-rest-storage/pull/127). They were replaced with just the _Interface_. Now the code was added again.