### PR TITLE
Do not log warnings for non-number redis metrics

### DIFF
--- a/src/main/java/org/swisspush/reststorage/redis/RedisMonitor.java
+++ b/src/main/java/org/swisspush/reststorage/redis/RedisMonitor.java
@@ -114,9 +114,7 @@ public class RedisMonitor {
                     publisher.publishMetric(key, value);
                 }
             } catch (NumberFormatException e) {
-                if(log.isTraceEnabled()) {
-                    log.trace("ignore field '{}' because '{}' doesnt look number-ish enough", key, valueStr);
-                }
+                log.trace("ignore field '{}' because '{}' doesnt look number-ish enough", key, valueStr);
             }
         });
     }

--- a/src/main/java/org/swisspush/reststorage/redis/RedisMonitor.java
+++ b/src/main/java/org/swisspush/reststorage/redis/RedisMonitor.java
@@ -114,7 +114,9 @@ public class RedisMonitor {
                     publisher.publishMetric(key, value);
                 }
             } catch (NumberFormatException e) {
-                log.warn("ignore field '{}' because '{}' doesnt look number-ish enough", key, valueStr);
+                if(log.isTraceEnabled()) {
+                    log.trace("ignore field '{}' because '{}' doesnt look number-ish enough", key, valueStr);
+                }
             }
         });
     }


### PR DESCRIPTION
Since there are many entries when calling redis INFO which are not numbers only, a lot of warnings are logged.